### PR TITLE
Make ranged and melee weapons smeltable

### DIFF
--- a/Defs/RecipeDefs/Recipes_Production.xml
+++ b/Defs/RecipeDefs/Recipes_Production.xml
@@ -2,6 +2,42 @@
 <RecipeDefs>
 
   <RecipeDef>
+    <defName>SmeltWeapon</defName>
+    <label>smelt weapon</label>
+    <description>Use heat and strong electromagnets to break down weapons into useful resources.</description>
+    <jobString>Smelting weapon.</jobString>
+    <workAmount>1600</workAmount>
+    <workSpeedStat>SmeltingSpeed</workSpeedStat>
+    <effectWorking>Smelt</effectWorking>
+    <soundWorking>Recipe_Smelt</soundWorking>
+    <specialProducts>
+      <li>Smelted</li>
+    </specialProducts>
+    <ingredients>
+      <li>
+        <filter>
+          <categories>
+            <li>Weapons</li>
+          </categories>
+        </filter>
+        <count>1</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <categories>
+        <li>WeaponsRanged</li>
+        <li>WeaponsMelee</li>
+      </categories>
+      <specialFiltersToDisallow>
+        <li>AllowNonSmeltableWeapons</li>
+      </specialFiltersToDisallow>
+    </fixedIngredientFilter>
+    <forceHiddenSpecialFilters>
+      <li>AllowSmeltable</li>
+    </forceHiddenSpecialFilters>
+  </RecipeDef>
+
+  <RecipeDef>
     <defName>MakeComponent</defName>
     <label>make component</label>
     <description>Make a component.</description>

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -119,9 +119,6 @@
         <onlyManualCast>true</onlyManualCast>
       </li>
     </verbs>
-    <smeltProducts>
-      <Steel>2</Steel>
-    </smeltProducts>
   </ThingDef>
 
 
@@ -252,9 +249,6 @@
         <onlyManualCast>true</onlyManualCast>
       </li>
     </verbs>
-    <smeltProducts>
-      <Steel>2</Steel>
-    </smeltProducts>
   </ThingDef>
 
   <!-- ==================== Flashbang grenade ========================== -->
@@ -316,9 +310,6 @@
         <onlyManualCast>true</onlyManualCast>
       </li>
     </verbs>
-    <smeltProducts>
-      <Steel>2</Steel>
-    </smeltProducts>
   </ThingDef>
 
 </ThingDefs>

--- a/Defs/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Guns.xml
@@ -23,6 +23,7 @@
     <alwaysHaulable>True</alwaysHaulable>
     <tickerType>Never</tickerType>
     <techLevel>Industrial</techLevel>
+    <smeltable>true</smeltable>
     <thingCategories>
       <li>WeaponsRanged</li>
     </thingCategories>
@@ -43,9 +44,6 @@
         <minQualityForArtistic>Excellent</minQualityForArtistic>
       </li>
     </comps>
-    <smeltProducts>
-      <Steel>20</Steel>
-    </smeltProducts>
   </ThingDef>
 
   <ThingDef Name="BaseMakeableGun" ParentName="BaseGun" Abstract="True">

--- a/Defs/ThingDefs_Misc/Weapons_Melee.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Melee.xml
@@ -22,6 +22,7 @@
     <alwaysHaulable>True</alwaysHaulable>
     <tickerType>Never</tickerType>
     <techLevel>Industrial</techLevel>
+    <smeltable>true</smeltable>
     <weaponTags>
       <li>Melee</li>
     </weaponTags>

--- a/Defs/ThingDefs_Misc/Weapons_Turrets.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Turrets.xml
@@ -11,6 +11,7 @@
     <destroyOnDrop>True</destroyOnDrop>
     <menuHidden>True</menuHidden>
     <canBeSpawningInventory>false</canBeSpawningInventory>
+    <smeltable>false</smeltable>
   </ThingDef>
 
   <ThingDef Name="BaseAutoTurretGun" ParentName="BaseTurretGun" Abstract="True">


### PR DESCRIPTION
Ranged and melee weapons are now smeltable. The amount of resources
returned appears to be the production cost of the weapon, modified by
and efficency factor of 0.25. I'm not sure where the efficiency factor
is set.

Turrets, grenades and ammunition are not smeltable. The production of
these is defined through a RecipeDef external to the ThingDef, whereas
the production of guns and melee weapons is defined through a
recipeMaker and costList internal to the ThingDef. This does not
appear to work with the method of setting the Thing to smeltable=true.

Smelting grenades and ammunition has fundamental problems as the game
does not appear to provide a way of smelting stacks, and those are
produced in stacks. Besides not having the smelting products
automatically determined by the production cost, having to smelt each
item in the stack individually seriously unbalances the work cost and
makes balancing the resources difficult.

Making turrets smeltable with the proper amount of resources returned
is likely possible. However, having them no longer smeltable is not a
regression as smelting turrets did not previously return any
resources, anyway.

In short, the only things smeltable are ranged and melee weapons, but
everything smeltable should return the correct amount and type of
resources.

Fixes #45