### PR TITLE
Allow Set and Get Pawn Loadout via its UniqueID

### DIFF
--- a/Source/CombatRealism/Combat_Realism/Loadouts/MapComp_LoadoutManager.cs
+++ b/Source/CombatRealism/Combat_Realism/Loadouts/MapComp_LoadoutManager.cs
@@ -151,6 +151,11 @@ namespace Combat_Realism
             return label;
         }
 
+        internal static Loadout GetLoadoutById(int id)
+        {
+            return Loadouts.Find(x => x.uniqueID == id);
+        }
+
         #endregion Methods
     }
 }

--- a/Source/CombatRealism/Combat_Realism/Loadouts/Utility_Loadouts.cs
+++ b/Source/CombatRealism/Combat_Realism/Loadouts/Utility_Loadouts.cs
@@ -150,6 +150,11 @@ namespace Combat_Realism
             return loadout;
         }
 
+        public static int GetLoadoutId(this Pawn pawn)
+        {
+            return GetLoadout(pawn).uniqueID;
+        }
+
         public static string GetWeightAndBulkTip(this Loadout loadout)
         {
             return loadout.GetWeightTip() + "\n\n" + loadout.GetBulkTip();
@@ -216,6 +221,15 @@ namespace Combat_Realism
                 LoadoutManager.AssignedLoadouts[pawn] = loadout;
             else
                 LoadoutManager.AssignedLoadouts.Add(pawn, loadout);
+        }
+
+        public static void SetLoadoutById(this Pawn pawn, int loadoutId)
+        {
+            Loadout loadout = LoadoutManager.GetLoadoutById(loadoutId);
+            if (loadout == null)
+                throw new ArgumentNullException("loadout");
+
+            SetLoadout(pawn, loadout);
         }
 
         public static void UpdateColonistCapacities()


### PR DESCRIPTION
These two methods allow to GetLoadoutId and SetLoadoutById using Reflection. These way, any mod can Get and Set pawn's loadouts without requiring to reference a Loadout class.