### PR TITLE
Fix for the gear tab's drop button when the item is minified.

### DIFF
--- a/Source/CombatRealism/Combat_Realism/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatRealism/Combat_Realism/Loadouts/ITab_Inventory.cs
@@ -344,7 +344,9 @@ namespace Combat_Realism
             else if (!t.def.destroyOnDrop)
             {
                 Thing thing;
-                this.SelPawnForGear.inventory.innerContainer.TryDrop(t, this.SelPawnForGear.Position, this.SelPawnForGear.Map, ThingPlaceMode.Near, out thing, null);
+                this.SelPawnForGear.inventory.innerContainer.TryDrop(
+                	t.def.Minifiable ? this.SelPawnForGear.inventory.innerContainer.FirstOrDefault(x => x.GetInnerIfMinified().ThingID == t.ThingID) : t, 
+                	this.SelPawnForGear.Position, this.SelPawnForGear.Map, ThingPlaceMode.Near, out thing, null);
             }
         }
 


### PR DESCRIPTION
If a pawn has a minified item in their inventory (no loadout) clicking the drop button in the gear tab causes an error about the item not existing in their inventory and the item remains stuck in their inventory.

This becomes much more of an issue if pawns have the ability to put minified items into their loadout (something I'm playing with).