### PR TITLE
Proposed fix for null dutyDefToSubNode.

### DIFF
--- a/Defs/ThinkTreeDefs/SubTrees_Duty.xml
+++ b/Defs/ThinkTreeDefs/SubTrees_Duty.xml
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ThinkTrees>
+
+
+  <!--============= AI Duty ============-->
+  <ThinkTreeDef>
+    <defName>LordDuty</defName>
+    <thinkRoot Class="ThinkNode_Priority">
+      <subNodes>
+        <li Class="ThinkNode_ConditionalHasLord">
+          <subNodes>
+            <li Class="ThinkNode_Duty"/>
+
+            <!-- If doesn't have voluntarily joinable lord -->
+            <!-- (otherwise we let pawns do something else if they get no job from the voluntarily joinable lord) -->
+            <li Class="ThinkNode_ConditionalHasVoluntarilyJoinableLord">
+              <invert>true</invert>
+              <subNodes>
+                <!-- If no duty issued a job -->
+                <!-- Wander at fallback -->
+                <li Class="ThinkNode_ConditionalHasFallbackLocation" >
+                  <subNodes>
+                    <li Class="JobGiver_WanderNearFallbackLocation" />
+                  </subNodes>
+                </li>
+
+                <li Class="JobGiver_WanderAnywhere" />
+                <li Class="JobGiver_IdleError" />
+              </subNodes>
+            </li>
+          </subNodes>
+        </li>
+      </subNodes>
+    </thinkRoot>
+  </ThinkTreeDef>
+
+  <ThinkTreeDef>
+    <defName>LordDutyConstant</defName>
+    <thinkRoot Class="ThinkNode_Priority">
+      <subNodes>
+        <li Class="ThinkNode_ConditionalHasLord">
+          <subNodes>
+            <li Class="ThinkNode_DutyConstant" />
+          </subNodes>
+        </li>
+      </subNodes>
+    </thinkRoot>
+  </ThinkTreeDef>
+
+
+
+
+</ThinkTrees>
+
+


### PR DESCRIPTION
TLDR; looking at #80, figured out that SubTrees_Duty.xml needed to be copied over from Core.

I don't really get WHY it works I just know that after a LOT of troubleshooting and following code flow I ended up finding the problem was XML related, popping up when ThinkTreeDefs/Humanlike.xml loaded successfully from Combat Realism.

Some more troubleshooting led me to LordDutyConstant near the end of the file that when present the error happened.  Checked Core and it's there too.  Noticed it was defined in SubTrees_Duty.xml so just copied that file over from Core into Combat Realism.  No errors.

The part that confuses me is that I thought once something was defined in a lower level and non-abstract (ie the treeDef LordDutyConstant in Core) that you didn't need to re-define it higher up (ie Combat Realism).