### PR TITLE
Fix for missing round brackets in validatorWS predicate. Fixes #87

### DIFF
--- a/Source/CombatRealism/Combat_Realism/Jobs/JobGiver_TakeAndEquip.cs
+++ b/Source/CombatRealism/Combat_Realism/Jobs/JobGiver_TakeAndEquip.cs
@@ -256,7 +256,7 @@ namespace Combat_Realism
                         Predicate<Thing> validatorWS = (Thing w) => w.def.IsWeapon
                         && w.MarketValue > 500 && pawn.CanReserve(w, 1)
                         && pawn.CanReach(w, PathEndMode.Touch, Danger.Deadly, true)
-                        && (!pawn.Faction.HostileTo(Faction.OfPlayer) && pawn.Map.areaManager.Home[w.Position]) || (pawn.Faction.HostileTo(Faction.OfPlayer))
+                        && ((!pawn.Faction.HostileTo(Faction.OfPlayer) && pawn.Map.areaManager.Home[w.Position]) || (pawn.Faction.HostileTo(Faction.OfPlayer)))
                         && (w.Position.DistanceToSquared(pawn.Position) < 15f || room == RoomQuery.RoomAtFast(w.Position, pawn.Map));
                         List<Thing> weapon = (
                             from w in pawn.Map.listerThings.ThingsInGroup(ThingRequestGroup.HaulableAlways)


### PR DESCRIPTION
Look like there was missing round brackets in validatorWS predicate. This resulted to wrong weapon list formed with items of any type, not only IsWeapon. 

Fixes #87 